### PR TITLE
Altmeter Simulation via I2C bus

### DIFF
--- a/Arduino/main/Altmeter.cpp
+++ b/Arduino/main/Altmeter.cpp
@@ -1,0 +1,113 @@
+#include "Altmeter.h"
+#include <Wire.h>
+
+static float set_altitude;
+static float set_temperature;
+static int latest_reg_address; //latest stored command. Data that we send back will depend on this
+
+//We send altititude through I2C as a 20-bit value, represented via 3 bytes
+static char altitude_values[3];
+
+//we send the temperature as a 12-bit value, in 2 bytes. The 4 msb of the last byte is the fractional component
+static char temperature_values[2];
+
+static void onAltmeterReceive(int numBytes);
+static void onAltmeterRequest(void);
+
+void initAltmeter(){
+    //start I2C communication as a slave with an address that corresponds to altmeter
+    Wire.begin(ALTMETER_I2C_ADDRESS);
+    Wire.onRequest(onAltmeterRequest);
+    Wire.onReceive(onAltmeterReceive);
+}
+
+void setAltitude(float alt){
+    set_altitude = alt;
+}
+
+void setTemperature(float temp){
+    set_temperature = temp;
+}
+
+/**
+ * Converts the float altitude into a set of 3 bytes that our clients will interpret
+ * From the documentation, the first 2 bytes (16-bits) contain the integer portion
+ * of the altitude, and the 4 most significant bits of the last byte (OUT_P_LSB)
+ * contains the unsigned floating point decimal. Therefore we must send it our floating
+ * point altitude in the corresponding way. The altitude data sent is therefore
+ * 20-bits
+ **/
+static void updateAltitudeValues(void){
+   //cast to an int to get rid of the floating point, bit shift 8 to the right to get the 8 most significant bits
+   altitude_values[0] = (((int)set_altitude) >> 8);
+
+   //simply take the first 8 lsb of the integer altitude
+   altitude_values[1] = ((int)set_altitude);
+
+   //getting the floating point is a little bit tricky. The client expects 4 bits located as the most significant
+   //bit of the last byte sent. To interprete the floating point, they will shift it 4 bits to the right, and devide
+   //the resulting value by 16.0 to retrieve the floating point value. For example if we send 0b11110000, client shifts it
+   //to 0b00001111, and devides by 16. Therefore we must multiply our floating point by 16, then shift 4 to the left.
+   altitude_values[2] = (int)(((set_altitude - (int)set_altitude))*16); //get the floating point of our number and multiply by 16, cast to int
+   altitude_values[2] <<= 4; //bitshift so the last 4 msb contain the floating point
+}
+
+/**
+ * Converts the floating point temperature (in C)
+ */
+static void updateTemperatureValues(void){
+  
+  temperature_values[0] = (int)set_temperature;
+
+  //subtract 1 since the client is expecting the 2's complement representation for negative numbers, and thus
+  //will add one when parsing
+  if(set_temperature < 0){
+    temperature_values[0] --;
+  }
+  temperature_values[1] = (int)((set_temperature - (int)set_temperature)*16);
+  temperature_values[1] <<= 4;
+}
+
+/**
+ * When we receive a command for the altmeter
+ * Note this function must return void and take in an integer, as described in the
+ * arduino specifications
+ **/
+static void onAltmeterReceive(int numBytes){
+  //just read the register address received, and discard any values that we may have received otherwise
+  latest_reg_address = Wire.read();
+
+  //clear the buffer since we don't care about the command values we received
+  while(Wire.available()){
+      Wire.read();
+  }
+}
+
+/**
+ * When we receive a request for data for the altmeter
+ * Note the function return type and parameters must both be void
+ **/
+static void onAltmeterRequest(void){
+    switch(latest_reg_address){
+        case STATUS:
+            //Only the 2nd bit needs to be set to 1. This lets the clients know that new altitude/pressure data is available
+            //In our case since we're simulating it it will always be available, so we'll set it to 1
+            //Read the datasheet for the STATUS register for more info
+            Wire.write(0b00000010);
+            break;
+        case OUT_P_MSB: //if the client is requesting altitude/pressure data
+            updateAltitudeValues();
+            Wire.write(altitude_values[0]);
+            Wire.write(altitude_values[1]);
+            Wire.write(altitude_values[2]);
+            break;
+        case OUT_T_MSB: //if the client is requesting temperature
+            updateTemperatureValues();
+            Wire.write(temperature_values[0]);
+            Wire.write(temperature_values[1]); //write 0 for now
+            break;
+        default: //just send something random for anything else the client wants
+            Wire.write(0b00000000);
+            break;
+    }
+}

--- a/Arduino/main/Altmeter.h
+++ b/Arduino/main/Altmeter.h
@@ -24,54 +24,12 @@
 
 /**
  * Define various register addresses that correspond to the altitude sensor we're using
- * The names correspond to the register values found in the data sheet
+ * The names correspond to the register values found in the data sheet. There are far more
+ * but these are the ones we actually care about
  **/
 #define STATUS     0x00
 #define OUT_P_MSB  0x01
-#define OUT_P_CSB  0x02
-#define OUT_P_LSB  0x03
 #define OUT_T_MSB  0x04
-#define OUT_T_LSB  0x05
-#define DR_STATUS  0x06
-#define OUT_P_DELTA_MSB  0x07
-#define OUT_P_DELTA_CSB  0x08
-#define OUT_P_DELTA_LSB  0x09
-#define OUT_T_DELTA_MSB  0x0A
-#define OUT_T_DELTA_LSB  0x0B
-#define WHO_AM_I   0x0C
-#define F_STATUS   0x0D
-#define F_DATA     0x0E
-#define F_SETUP    0x0F
-#define TIME_DLY   0x10
-#define SYSMOD     0x11
-#define INT_SOURCE 0x12
-#define PT_DATA_CFG 0x13
-#define BAR_IN_MSB 0x14
-#define BAR_IN_LSB 0x15
-#define P_TGT_MSB  0x16
-#define P_TGT_LSB  0x17
-#define T_TGT      0x18
-#define P_WND_MSB  0x19
-#define P_WND_LSB  0x1A
-#define T_WND      0x1B
-#define P_MIN_MSB  0x1C
-#define P_MIN_CSB  0x1D
-#define P_MIN_LSB  0x1E
-#define T_MIN_MSB  0x1F
-#define T_MIN_LSB  0x20
-#define P_MAX_MSB  0x21
-#define P_MAX_CSB  0x22
-#define P_MAX_LSB  0x23
-#define T_MAX_MSB  0x24
-#define T_MAX_LSB  0x25
-#define CTRL_REG1  0x26
-#define CTRL_REG2  0x27
-#define CTRL_REG3  0x28
-#define CTRL_REG4  0x29
-#define CTRL_REG5  0x2A
-#define OFF_P      0x2B
-#define OFF_T      0x2C
-#define OFF_H      0x2D
 
 /**
  * Sets up i2c communication as a slave on the bus

--- a/Arduino/main/Altmeter.h
+++ b/Arduino/main/Altmeter.h
@@ -1,0 +1,94 @@
+/**
+ * @file Altmeter.h
+ * @author Serj Babayan
+ * @date Dec 28, 2016
+ * @brief Altmeter sensor simulation using the Arduino Mega
+ * @copyright Waterloo Aerial Robotics Group 2016 \n
+ *   https://raw.githubusercontent.com/UWARG/WARG-Sim/master/LICENCE
+ *
+ * @see https://www.sparkfun.com/products/11084 for documentation on the sensor, including
+ * its data sheet and existing reference arduino library that this was based off of
+ *
+ * @notes
+ * Because a single arduino can enter an I2C bus as either a master or a slave with a specified master,
+ * it may not be possible to simulate multiple I2C sensors with a single arduino. For now this is fine
+ * as the only I2C sensor used on the picpilot is the altmeter.
+ *
+ * Also please note that the sensor being simulated will ALWAYS be in ALTITUDE_MODE simply
+ * because we don't really care about BAROMETER mode in our case (we want heights not pressure). If you're
+ * confused as to what the two modes do read the data sheet for the sensor.
+ **/
+
+/** Address predefined as listed in the datasheet **/
+#define ALTMETER_I2C_ADDRESS 0x60
+
+/**
+ * Define various register addresses that correspond to the altitude sensor we're using
+ * The names correspond to the register values found in the data sheet
+ **/
+#define STATUS     0x00
+#define OUT_P_MSB  0x01
+#define OUT_P_CSB  0x02
+#define OUT_P_LSB  0x03
+#define OUT_T_MSB  0x04
+#define OUT_T_LSB  0x05
+#define DR_STATUS  0x06
+#define OUT_P_DELTA_MSB  0x07
+#define OUT_P_DELTA_CSB  0x08
+#define OUT_P_DELTA_LSB  0x09
+#define OUT_T_DELTA_MSB  0x0A
+#define OUT_T_DELTA_LSB  0x0B
+#define WHO_AM_I   0x0C
+#define F_STATUS   0x0D
+#define F_DATA     0x0E
+#define F_SETUP    0x0F
+#define TIME_DLY   0x10
+#define SYSMOD     0x11
+#define INT_SOURCE 0x12
+#define PT_DATA_CFG 0x13
+#define BAR_IN_MSB 0x14
+#define BAR_IN_LSB 0x15
+#define P_TGT_MSB  0x16
+#define P_TGT_LSB  0x17
+#define T_TGT      0x18
+#define P_WND_MSB  0x19
+#define P_WND_LSB  0x1A
+#define T_WND      0x1B
+#define P_MIN_MSB  0x1C
+#define P_MIN_CSB  0x1D
+#define P_MIN_LSB  0x1E
+#define T_MIN_MSB  0x1F
+#define T_MIN_LSB  0x20
+#define P_MAX_MSB  0x21
+#define P_MAX_CSB  0x22
+#define P_MAX_LSB  0x23
+#define T_MAX_MSB  0x24
+#define T_MAX_LSB  0x25
+#define CTRL_REG1  0x26
+#define CTRL_REG2  0x27
+#define CTRL_REG3  0x28
+#define CTRL_REG4  0x29
+#define CTRL_REG5  0x2A
+#define OFF_P      0x2B
+#define OFF_T      0x2C
+#define OFF_H      0x2D
+
+/**
+ * Sets up i2c communication as a slave on the bus
+ */
+void initAltmeter(void);
+
+/**
+ * Set the altitude that the arduino mega will send to the picpilot through
+ * I2C. In metres
+ **/
+void setAltitude(float alt);
+
+/**
+ * Sets the temperature that the arduino mega will send back. Temperature is currently
+ * not used within the picpilot, however it may be used in some other arduino examples
+ * for the altitude sensor. In C degrees. Note the highest temperature that can be sent is
+ * limited by the 12-bit value that the sensor is expected to send back, therefore it must be between
+ * -127 and 128
+ **/
+void setTemperature(float temp);

--- a/Arduino/main/main.ino
+++ b/Arduino/main/main.ino
@@ -1,17 +1,24 @@
 #include "RCReceiver.h"
+#include "Altmeter.h"
 
-long current_time = 0;
-PWMData* pwmState;
+//long current_time = 0;
+//PWMData* pwmState;
+float altitude = 122.0;
+float temperature = -32;
 
 void setup() {
     // put your setup code here, to run once:
     Serial.begin(9600);
 
-    initRCReceiver();
-    current_time = micros();
+    //initRCReceiver();
+    //current_time = micros();
+    initAltmeter();
+    setAltitude(123.00);
+    setTemperature(temperature);
 }
 
 void loop() {
+/*
     if((micros() - current_time) > 1000000){
         pwmState = getCurrentPWMState();
 
@@ -25,4 +32,10 @@ void loop() {
         Serial.println("Right Tail");
         Serial.println((*pwmState)[3]);
     }
+    */
+    delay(1000);
+    altitude += 0.15;
+    temperature += 0.1;
+    setTemperature(temperature);
+    setAltitude(altitude);
 }


### PR DESCRIPTION
Successfully emulated the altmeter. The arduino mega willl enter as a slave with the same address as the altmeter, and will send back the currently set altitude when it is requested.

I tested this with 2 arduino's. One ran the example script from sparkfun, while the other one ran this code. The arduino was successfully tricked and correctly parsed the fake altitude values.

Did not test this on the picpilot since its a 3.3V chip, and I dont have the necessary mosfets to build a bidirectional level shifter, which will be required for I2C. I ordered a few of those boards a while ago so hopefully I'll be able to test it then (however I expect 99% that it will work).

As an added bonus also added the ability to set the temperature. We don't use it on the pic but if we do we'll have it.

If you have 2 arduino's and would like to test this yourself, simply download and load the arduino sparkfun library on one of the arduino's : 

https://github.com/sparkfun/MPL3115A2_Breakout/tree/V_H1.1_L1.2.0/Libraries/Arduino

Then load this code onto the other one, and connect the two via their respective SDA and SDC pins (make sure they have the same ground voltages). Then view the console log from the sparkfun code and look at the fake altitude values being interpreted.